### PR TITLE
feat: allow mass assignment for customer files

### DIFF
--- a/app/Models/CustomerFile.php
+++ b/app/Models/CustomerFile.php
@@ -10,6 +10,17 @@ class CustomerFile extends Model
     // Si prefieres que estos atributos aparezcan al serializar:
     // protected $appends = ['status', 'web_path', 'ext', 'size_human'];
 
+    /** Campos que se pueden asignar en masa (create / update). */
+    protected $fillable = [
+        'customer_id',
+        'url',
+        'creator_user_id',
+        'uuid',
+        'filename',
+        'size',
+        'mime_type',
+    ];
+
     public function creator()
     {
         return $this->belongsTo(User::class, 'creator_user_id')


### PR DESCRIPTION
## Summary
- enable mass assignment on `CustomerFile` by defining fillable fields for related file metadata

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf01fe7e08833183af01835bfd2de5