### PR TITLE
Fix order product delete link path

### DIFF
--- a/resources/views/orders/show.blade.php
+++ b/resources/views/orders/show.blade.php
@@ -459,7 +459,7 @@
 						 <div class="modal-body">
 							<p>@if(isset($item->product)){{$item->product->name}}@endif</p>
 						 <button type="button" class="btn btn-danger" data-dismiss="modal">Cancelar</button>
-						 <a href="/order/product/{{ $item->id }}/destroy"> 
+                                                <a href="/orders/product/{{ $item->id }}/destroy">
 							<input type="" value="Sí" data-toggle="modal" data-target="#destroy_{{$item->id}}" class="btn btn-primary" size="3"></a>
 						 </div>
 


### PR DESCRIPTION
## Summary
- correct the product delete link on the order detail view to target the existing /orders/product route

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cad628b8f88331bfd138d20f89793f