### PR TITLE
Expand duplicate phone check on customer creation

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -275,6 +275,14 @@ class CustomerController extends Controller
         return preg_replace('/[^0-9]/', '', $phoneNumber);
     }
 
+    protected function phoneNormalizationExpression(string $column): string
+    {
+        return sprintf(
+            "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(%s, ' ', ''), '-', ''), '(', ''), ')', ''), '+', ''), '.', ''), '/', '')",
+            $column
+        );
+    }
+
     public function updateDesmechadora()
     {
         $emails = $this->extractEmailsFromLogs(); // Asume que esta es la función que escribimos antes
@@ -635,6 +643,110 @@ class CustomerController extends Controller
      */
     public function store(Request $request)
     {
+        $phoneFields = [
+            'phone' => $request->phone,
+            'phone2' => $request->phone2,
+            'contact_phone2' => $request->contact_phone2,
+        ];
+
+        $rawPhoneValues = collect($phoneFields)
+            ->map(fn ($value) => trim((string) $value))
+            ->filter(fn ($value) => $value !== '')
+            ->unique()
+            ->values()
+            ->all();
+
+        $normalizedPhoneValues = collect($phoneFields)
+            ->map(fn ($value) => $this->normalizePhoneNumber(trim((string) $value)))
+            ->filter(fn ($value) => $value !== '')
+            ->unique()
+            ->values()
+            ->all();
+
+        $hasPhone = !empty($rawPhoneValues) || !empty($normalizedPhoneValues);
+
+        $duplicateQuery = Customer::query();
+        $hasConditions = false;
+
+        if ($request->filled('email')) {
+            $duplicateQuery->where(function ($query) use ($request) {
+                $query->where('email', $request->email)
+                    ->orWhere('contact_email', $request->email);
+            });
+            $hasConditions = true;
+        }
+
+        if ($hasPhone) {
+            $controller = $this;
+            $phoneConditions = function ($query) use ($rawPhoneValues, $normalizedPhoneValues, $controller) {
+                $columns = ['phone', 'phone2', 'contact_phone2'];
+                $firstColumn = true;
+
+                foreach ($columns as $column) {
+                    $columnConditions = function ($inner) use ($column, $rawPhoneValues, $normalizedPhoneValues, $controller) {
+                        $expression = $controller->phoneNormalizationExpression($column);
+                        $hasInnerCondition = false;
+
+                        if (!empty($rawPhoneValues)) {
+                            if (count($rawPhoneValues) === 1) {
+                                $inner->where($column, $rawPhoneValues[0]);
+                            } else {
+                                $inner->whereIn($column, $rawPhoneValues);
+                            }
+                            $hasInnerCondition = true;
+                        }
+
+                        foreach ($normalizedPhoneValues as $normalizedPhone) {
+                            if ($hasInnerCondition) {
+                                $inner->orWhereRaw("$expression = ?", [$normalizedPhone]);
+                            } else {
+                                $inner->whereRaw("$expression = ?", [$normalizedPhone]);
+                                $hasInnerCondition = true;
+                            }
+                        }
+
+                        if (!$hasInnerCondition) {
+                            $inner->whereRaw('0 = 1');
+                        }
+                    };
+
+                    if ($firstColumn) {
+                        $query->where($columnConditions);
+                        $firstColumn = false;
+                    } else {
+                        $query->orWhere($columnConditions);
+                    }
+                }
+            };
+
+            if ($hasConditions) {
+                $duplicateQuery->orWhere($phoneConditions);
+            } else {
+                $duplicateQuery->where($phoneConditions);
+                $hasConditions = true;
+            }
+        }
+
+        $duplicateCustomers = $hasConditions
+            ? $duplicateQuery
+                ->orderBy('id', 'desc')
+                ->get(['id', 'name', 'email', 'phone', 'phone2', 'contact_phone2'])
+            : collect();
+
+        if ($duplicateCustomers->isNotEmpty()) {
+            return redirect()->back()
+                ->withInput()
+                ->with([
+                    'duplicate_message' => 'Ya existe un cliente con el mismo correo o teléfono.',
+                    'duplicate_customers' => $duplicateCustomers
+                        ->map(function ($customer) {
+                            return $customer->only(['id', 'name', 'email', 'phone', 'phone2', 'contact_phone2']);
+                        })
+                        ->values()
+                        ->all(),
+                ]);
+        }
+
         $model = new Customer;
         $model->name = $request->name;
         $model->document = $request->document;

--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -2,6 +2,44 @@
 
 @section('content')
 <h1>Crear Cliente</h1>
+@if (session('duplicate_message'))
+    <div class="alert alert-warning" role="alert">
+        <strong>{{ session('duplicate_message') }}</strong>
+        @php
+            $duplicateCustomers = collect(session('duplicate_customers'));
+        @endphp
+        @if ($duplicateCustomers->isNotEmpty())
+            <p class="mt-2">Revisa los siguientes registros coincidentes:</p>
+            <ul>
+                @foreach ($duplicateCustomers as $customer)
+                    <li>
+                        @if (!empty($customer['id']))
+                            <a href="{{ route('customers.show', $customer['id']) }}" target="_blank">
+                                {{ $customer['name'] ?? 'Cliente sin nombre' }}
+                            </a>
+                        @else
+                            {{ $customer['name'] ?? 'Cliente sin nombre' }}
+                        @endif
+                        @php
+                            $emails = array_filter([($customer['email'] ?? null)]);
+                            $phones = array_filter([
+                                $customer['phone'] ?? null,
+                                $customer['phone2'] ?? null,
+                                $customer['contact_phone2'] ?? null,
+                            ]);
+                        @endphp
+                        @if (!empty($emails))
+                            <span>- Correo: {{ implode(', ', $emails) }}</span>
+                        @endif
+                        @if (!empty($phones))
+                            <span>- Teléfonos: {{ implode(', ', $phones) }}</span>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
+        @endif
+    </div>
+@endif
 {{-- FORMULARIO CLIENTES --}}
 <form method="POST" action="/customers">
 {{ csrf_field() }}


### PR DESCRIPTION
## Summary
- normalize the input values from phone, phone2 and contact_phone2 during customer creation
- reuse the collected values to detect duplicates across all stored phone columns before saving the record

## Testing
- php -l app/Http/Controllers/CustomerController.php

------
https://chatgpt.com/codex/tasks/task_e_68cd097841988331bab4284b3ad9551b