### PR TITLE
Restrict customer reassignment by role

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -43,6 +43,17 @@ class User extends Authenticatable
         return true;
     }
 
+    public function canAssignCustomers(): bool
+    {
+        $allowedRoles = array_map('intval', config('permissions.customer_assign_roles', []));
+
+        if ($this->role_id === null) {
+            return false;
+        }
+
+        return in_array((int) $this->role_id, $allowedRoles, true);
+    }
+
 
     public function searchChatables(string $query): Collection
     {

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'customer_assign_roles' => [1, 15],
+];

--- a/resources/views/customers/create.blade.php
+++ b/resources/views/customers/create.blade.php
@@ -266,15 +266,21 @@
     <label for="first_installment_date">Fecha de Compra:</label>
     <input type="date" class="form-control" name="date_bought" id="date_bought">
   </div>
-   {{-- Asignado a --}}
+  {{-- Asignado a --}}
   <div class="form-group">
     <label for="users">Asignado A:</label>
-    <select name="user_id" id="user_id" class="form-control">
-      <option value="">Seleccione...</option>
-      @foreach ($users as $item)
-      <option value="{{ $item->id }}">{{  $item->name }}</option>
-      @endforeach
-    </select>
+    @if ($canAssignCustomers)
+      @php $selectedUserId = old('user_id', $defaultAssignedUserId); @endphp
+      <select name="user_id" id="user_id" class="form-control">
+        <option value="">Seleccione...</option>
+        @foreach ($users as $item)
+          <option value="{{ $item->id }}" @selected((string) $selectedUserId === (string) $item->id)>{{  $item->name }}</option>
+        @endforeach
+      </select>
+    @else
+      <input type="hidden" name="user_id" value="{{ $defaultAssignedUserId }}">
+      <input type="text" class="form-control" value="{{ optional(Auth::user())->name }}" readonly>
+    @endif
   </div>
   {{-- fuente --}}
     <div class="">

--- a/resources/views/customers/daily.blade.php
+++ b/resources/views/customers/daily.blade.php
@@ -164,38 +164,44 @@ Registro <strong>{{ $model->currentPage()*$model->perPage() - ( $model->perPage(
 *    Combo de usuarios
 *
 -->
-          <script>
-            function updateUser(cid) {
-              console.log(cid);
-              var uid = $("#user_id_" + cid).val();
-              var parameters = {
-                customer_id: cid,
-                user_id: uid
-              };
-              console.log(parameters);
-              $.ajax({
-                data: parameters,
-                url: '/customers/ajax/update_user',
-                type: 'get',
-                beforeSend: function() {},
-                success: function(response) {
-                  console.log(response);
-                  $("#notication_area").css('display', 'block');
-                  $("#notication_area_text").html("Se actualizó el cliente " + response);
-                }
-              });
-            }
-          </script>
-          <select name="user_id" class="custom-select" id="user_id_{{$item->id}}" onchange="updateUser({{$item->id}});">
-            <option value="">Usuario...</option>
-            <option value="null">Sin asignar</option>
-            @foreach($users as $user)
-            <option value="{{$user->id}}" @if ($item->user_id == $user->id) selected="selected" @endif>
-              <?php echo substr($user->name, 0, 10); ?>
+          @if ($canAssignCustomers)
+            <script>
+              function updateUser(cid) {
+                console.log(cid);
+                var uid = $("#user_id_" + cid).val();
+                var parameters = {
+                  customer_id: cid,
+                  user_id: uid
+                };
+                console.log(parameters);
+                $.ajax({
+                  data: parameters,
+                  url: '/customers/ajax/update_user',
+                  type: 'get',
+                  beforeSend: function() {},
+                  success: function(response) {
+                    console.log(response);
+                    $("#notication_area").css('display', 'block');
+                    $("#notication_area_text").html("Se actualizó el cliente " + response);
+                  }
+                });
+              }
+            </script>
+            <select name="user_id" class="custom-select" id="user_id_{{$item->id}}" onchange="updateUser({{$item->id}});">
+              <option value="">Usuario...</option>
+              <option value="null">Sin asignar</option>
+              @foreach($users as $user)
+              <option value="{{$user->id}}" @if ($item->user_id == $user->id) selected="selected" @endif>
+                <?php echo substr($user->name, 0, 10); ?>
 
-            </option>
-            @endforeach
-          </select>
+              </option>
+              @endforeach
+            </select>
+          @else
+            <div class="form-control-plaintext">
+              {{ optional($item->user)->name ?? 'Sin asignar' }}
+            </div>
+          @endif
           <div id="customer_status_{{$item->id}}"></div>
 
 

--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -7,14 +7,20 @@
    {{-- Asignado a --}}
   <div class="form-group">
     <label for="users">Asignado A:</label>
-    <select name="user_id" id="user_id" class="form-control">
-      <option value="">Seleccione...</option>
-      @foreach ($users as $item)
-       @if($item->status_id == 1)
-        <option value="{{$item->id}}" @if($item->id==$model->user_id)selected="selected" @endif>{{$item->name}}</option>
-        @endif
-      @endforeach
-    </select>
+    @if ($canAssignCustomers)
+      @php $selectedUserId = old('user_id', $model->user_id); @endphp
+      <select name="user_id" id="user_id" class="form-control">
+        <option value="">Seleccione...</option>
+        @foreach ($users as $item)
+          @if($item->status_id == 1)
+            <option value="{{$item->id}}" @selected((string) $selectedUserId === (string) $item->id)>{{$item->name}}</option>
+          @endif
+        @endforeach
+      </select>
+    @else
+      <input type="hidden" name="user_id" value="{{ $lockedAssignedUserId }}">
+      <input type="text" class="form-control" value="{{ optional($model->user)->name ?? optional(Auth::user())->name }}" readonly>
+    @endif
   </div>
 
 

--- a/tests/Feature/CustomerAssignmentTest.php
+++ b/tests/Feature/CustomerAssignmentTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class CustomerAssignmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        $databaseFile = __DIR__ . '/../../database/database.sqlite';
+        if (! file_exists($databaseFile)) {
+            touch($databaseFile);
+        }
+
+        parent::setUp();
+
+        if (! Schema::hasColumn('users', 'role_id')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->unsignedBigInteger('role_id')->nullable();
+            });
+        }
+
+        if (! Schema::hasColumn('users', 'status_id')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->unsignedBigInteger('status_id')->nullable();
+            });
+        }
+
+        Schema::dropIfExists('customer_histories');
+        Schema::dropIfExists('customers');
+
+        Schema::create('customers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->string('document')->nullable();
+            $table->string('position')->nullable();
+            $table->string('business')->nullable();
+            $table->unsignedBigInteger('product_id')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('phone2')->nullable();
+            $table->string('email')->nullable();
+            $table->text('notes')->nullable();
+            $table->integer('count_empanadas')->nullable();
+            $table->string('address')->nullable();
+            $table->string('city')->nullable();
+            $table->string('country')->nullable();
+            $table->string('department')->nullable();
+            $table->string('bought_products')->nullable();
+            $table->decimal('total_sold', 15, 2)->nullable();
+            $table->date('purchase_date')->nullable();
+            $table->unsignedBigInteger('status_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->unsignedBigInteger('source_id')->nullable();
+            $table->boolean('technical_visit')->nullable();
+            $table->string('contact_name')->nullable();
+            $table->string('contact_phone2')->nullable();
+            $table->string('contact_email')->nullable();
+            $table->string('contact_position')->nullable();
+            $table->string('scoring_interest')->nullable();
+            $table->string('scoring_profile')->nullable();
+            $table->string('rd_public_url')->nullable();
+            $table->string('empanadas_size')->nullable();
+            $table->integer('number_venues')->nullable();
+            $table->unsignedBigInteger('updated_user_id')->nullable();
+            $table->unsignedBigInteger('creator_user_id')->nullable();
+            $table->string('maker')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('customer_histories', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('customer_id')->nullable();
+            $table->string('name')->nullable();
+            $table->string('document')->nullable();
+            $table->string('position')->nullable();
+            $table->string('business')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('phone2')->nullable();
+            $table->string('email')->nullable();
+            $table->text('notes')->nullable();
+            $table->string('address')->nullable();
+            $table->string('city')->nullable();
+            $table->string('country')->nullable();
+            $table->string('department')->nullable();
+            $table->string('bought_products')->nullable();
+            $table->unsignedBigInteger('status_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->unsignedBigInteger('source_id')->nullable();
+            $table->boolean('technical_visit')->nullable();
+            $table->unsignedBigInteger('updated_user_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function createCustomerOwnedBy(User $owner): Customer
+    {
+        $customer = new Customer();
+        $customer->name = 'Test Customer';
+        $customer->status_id = 1;
+        $customer->user_id = $owner->id;
+        $customer->save();
+
+        return $customer->fresh();
+    }
+
+    public function test_ajax_update_is_forbidden_for_user_without_permission(): void
+    {
+        $owner = User::factory()->create(['role_id' => 1]);
+        $target = User::factory()->create(['role_id' => 1]);
+        $unauthorized = User::factory()->create(['role_id' => 2]);
+
+        $customer = $this->createCustomerOwnedBy($owner);
+
+        $response = $this->actingAs($unauthorized)
+            ->get('/customers/ajax/update_user?customer_id=' . $customer->id . '&user_id=' . $target->id);
+
+        $response->assertForbidden();
+        $this->assertSame($owner->id, $customer->fresh()->user_id);
+    }
+
+    public function test_update_route_is_forbidden_for_user_without_permission(): void
+    {
+        $owner = User::factory()->create(['role_id' => 1]);
+        $target = User::factory()->create(['role_id' => 1]);
+        $unauthorized = User::factory()->create(['role_id' => 2]);
+
+        $customer = $this->createCustomerOwnedBy($owner);
+
+        $response = $this->actingAs($unauthorized)->post("/customers/{$customer->id}/update", [
+            'name' => 'Updated Name',
+            'phone' => '123456789',
+            'user_id' => $target->id,
+        ]);
+
+        $response->assertForbidden();
+        $this->assertSame($owner->id, $customer->fresh()->user_id);
+    }
+
+    public function test_authorized_user_can_reassign_via_ajax(): void
+    {
+        $authorized = User::factory()->create(['role_id' => 1]);
+        $target = User::factory()->create(['role_id' => 15]);
+        $customer = $this->createCustomerOwnedBy($authorized);
+
+        $response = $this->actingAs($authorized)
+            ->get('/customers/ajax/update_user?customer_id=' . $customer->id . '&user_id=' . $target->id);
+
+        $response->assertOk();
+        $this->assertSame($target->id, $customer->fresh()->user_id);
+    }
+
+    public function test_authorized_user_can_reassign_via_update_route(): void
+    {
+        $authorized = User::factory()->create(['role_id' => 1]);
+        $target = User::factory()->create(['role_id' => 15]);
+        $customer = $this->createCustomerOwnedBy($authorized);
+
+        $response = $this->actingAs($authorized)->post("/customers/{$customer->id}/update", [
+            'name' => 'Updated Name',
+            'phone' => '123456789',
+            'user_id' => $target->id,
+        ]);
+
+        $response->assertRedirect("/customers/{$customer->id}/show");
+        $this->assertSame($target->id, $customer->fresh()->user_id);
+    }
+}


### PR DESCRIPTION
## Summary
- add a permission helper and configuration for customer reassignment roles
- enforce the helper across customer creation, updates, and daily assignment flows while adjusting the UI
- cover authorized and unauthorized assignment attempts with new feature tests

## Testing
- ⚠️ `composer install` *(fails: repeated 403 errors while downloading packages)*
- ⚠️ `php artisan test` *(fails: vendor autoload not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b114c3048331aaadab7a2000d174