### PR TITLE
Limit action deletion to customer assignment roles and enable soft deletes

### DIFF
--- a/app/Http/Controllers/ActionController.php
+++ b/app/Http/Controllers/ActionController.php
@@ -236,10 +236,24 @@ class ActionController extends Controller
     public function destroy($id)
     {
         $model = Action::find($id);
-        $customer_id = $model->customer_id;
-        if ($model->delete()) {
-            return redirect('customers/'.$customer_id."/show")->with('statusone', 'La acción <strong>'.$model->name.'</strong> fué eliminada con éxito!'); 
+
+        if (!$model) {
+            return redirect()->back()->with('statustwo', 'La acción solicitada no existe.');
         }
+
+        $user = Auth::user();
+
+        if (!$user || !$user->canDeleteActions()) {
+            return redirect('customers/'.$model->customer_id."/show")->with('statustwo', 'No tienes permisos para eliminar acciones.');
+        }
+
+        $customer_id = $model->customer_id;
+
+        if ($model->delete()) {
+            return redirect('customers/'.$customer_id."/show")->with('statusone', 'La acción <strong>'.$model->note.'</strong> fue eliminada con éxito!');
+        }
+
+        return redirect()->back()->with('statustwo', 'No fue posible eliminar la acción.');
     }
 
 

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -4,9 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 // use Laravel\Scout\Searchable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Action extends Model
 {
+    use SoftDeletes;
+
        /** Campos que se pueden asignar en masa (create / update). */
     protected $fillable = [
         'note',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -54,6 +54,11 @@ class User extends Authenticatable
         return in_array((int) $this->role_id, $allowedRoles, true);
     }
 
+    public function canDeleteActions(): bool
+    {
+        return $this->canAssignCustomers();
+    }
+
 
     public function searchChatables(string $query): Collection
     {

--- a/database/migrations/2024_05_20_000000_add_soft_deletes_to_actions_table.php
+++ b/database/migrations/2024_05_20_000000_add_soft_deletes_to_actions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasColumn('actions', 'deleted_at')) {
+            Schema::table('actions', function (Blueprint $table) {
+                $table->softDeletes()->after('updated_at');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('actions', 'deleted_at')) {
+            Schema::table('actions', function (Blueprint $table) {
+                $table->dropSoftDeletes();
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- enable soft deletes on the actions model and add a migration to persist the deleted_at column
- gate action deletions so only the roles that can assign customers may remove them
- reuse the existing role configuration through a new helper on the user model and improve feedback when a delete fails

## Testing
- `./vendor/bin/phpunit` *(fails: file not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e69ea9b22883318762fcb472200f18