### PR TITLE
Prevent unauthorized reassignment when editing customers

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -912,7 +912,7 @@ class CustomerController extends Controller
         $products = Product::all();
         $authUser = Auth::user();
         $canAssignCustomers = $authUser?->canAssignCustomers() ?? false;
-        $lockedAssignedUserId = $model->user_id ?? ($authUser?->id ?? null);
+        $lockedAssignedUserId = $model->user_id;
 
         return view('customers.edit', compact('products', 'model', 'customer_statuses', 'users', 'customer_sources', 'scoring_profile', 'canAssignCustomers', 'lockedAssignedUserId'));
     }
@@ -956,9 +956,9 @@ class CustomerController extends Controller
         $requestedUserId = $request->has('user_id')
             ? $this->normalizeUserId($request->input('user_id'))
             : $currentUserId;
-        $lockedUserId = $currentUserId ?? ($authUser?->id ?? null);
+        $lockedUserId = $currentUserId;
 
-        if (! $canAssignCustomers && $request->has('user_id') && $requestedUserId !== $lockedUserId) {
+        if (! $canAssignCustomers && $request->filled('user_id') && $requestedUserId !== $lockedUserId) {
             abort(403);
         }
 
@@ -980,7 +980,7 @@ class CustomerController extends Controller
         $model->technical_visit = $request->technical_visit;
         $model->bought_products = $request->bought_products;
         $model->purchase_date = $request->purchase_date;
-        $model->user_id = $canAssignCustomers ? $requestedUserId : $lockedUserId;
+        $model->user_id = $canAssignCustomers ? $requestedUserId : $currentUserId;
         $model->source_id = $request->source_id;
         $model->status_id = $request->status_id;
         //Agregamos el producto en edicion de prospecto

--- a/resources/views/customers/edit.blade.php
+++ b/resources/views/customers/edit.blade.php
@@ -19,7 +19,7 @@
       </select>
     @else
       <input type="hidden" name="user_id" value="{{ $lockedAssignedUserId }}">
-      <input type="text" class="form-control" value="{{ optional($model->user)->name ?? optional(Auth::user())->name }}" readonly>
+      <input type="text" class="form-control" value="{{ optional($model->user)->name ?? 'Sin asignar' }}" readonly>
     @endif
   </div>
 


### PR DESCRIPTION
## Summary
- stop defaulting the customer owner to the current user when they lack assignment permissions
- keep the current assignee when restricted users update customer records and show "Sin asignar" for unassigned customers

## Testing
- php -l app/Http/Controllers/CustomerController.php

------
https://chatgpt.com/codex/tasks/task_e_68eea8d8efbc83318ea71a91a36f15bb