### PR TITLE
Improve user edit form password visibility and file-input styling

### DIFF
--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -14,19 +14,11 @@
    
     <input type="text" class="form-control" id="email" name="email" placeholder="email" required="required" value="{{$user->email}}">
   </div>
-  <div class="card mb-3">
-    <div class="card-header p-2">
-      <button class="btn btn-link p-0" type="button" data-toggle="collapse" data-target="#passwordCollapse" aria-expanded="false" aria-controls="passwordCollapse">
-        Cambiar contraseña (opcional)
-      </button>
-    </div>
-    <div id="passwordCollapse" class="collapse">
-      <div class="card-body">
-        <div class="form-group mb-0">
-          <label for="password">Nueva contraseña:</label>
-          <input type="password" class="form-control" id="password" name="password" placeholder="Dejar vacío para no cambiar">
-        </div>
-      </div>
+  <div class="mb-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+    <div class="form-group mb-0">
+      <label for="password">Nueva contraseña (opcional):</label>
+      <input type="password" class="form-control" id="password" name="password" placeholder="Dejar vacío para no cambiar">
+      <small class="form-text text-muted">Solo completa este campo si deseas actualizar la contraseña.</small>
     </div>
   </div>
   <div class="form-group">
@@ -61,7 +53,7 @@
         <img src="{{ $currentAvatar }}" alt="Foto de {{ $user->name }}" class="rounded-circle" style="width: 80px; height: 80px; object-fit: cover;">
       </div>
     @endif
-    <input type="file" id="profile_photo" name="profile_photo" class="form-control-file" accept=".jpg,.jpeg,.png,.webp">
+    <input type="file" id="profile_photo" name="profile_photo" class="mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 file:mr-4 file:rounded-md file:border-0 file:bg-slate-100 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-slate-700 hover:file:bg-slate-200 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:file:bg-slate-800 dark:file:text-slate-100 dark:hover:file:bg-slate-700" accept=".jpg,.jpeg,.png,.webp">
     <small class="form-text text-muted">Sube una nueva imagen para actualizar el perfil.</small>
   </div>
 

--- a/tests/Feature/UsersEditFormTest.php
+++ b/tests/Feature/UsersEditFormTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Models\User;
+
+it('shows the password and profile photo inputs on the user edit form', function () {
+    $user = User::factory()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->get("/users/{$user->id}/edit");
+
+    $response->assertOk();
+    $response->assertSee('name="password"', false);
+    $response->assertSee('name="profile_photo"', false);
+    $response->assertSee('file:rounded-md', false);
+});


### PR DESCRIPTION
### Motivation
- Users reported the password field disappears when editing and the profile photo file input looks unattractive, causing confusion on the edit page. 
- The collapsing password panel hides the field by default and can make users think the field is missing. 
- The file input used plain Bootstrap classes and didn't match the design system; Tailwind utilities provide a cleaner, consistent look. 

### Description
- Replaced the collapsing password card in `resources/views/users/edit.blade.php` with a visible, accessible block containing the password input and helper text. 
- Restyled the `profile_photo` file input with Tailwind utility classes to improve appearance and file button styling. 
- Added a Pest feature test `tests/Feature/UsersEditFormTest.php` that asserts the edit page contains the `password` and `profile_photo` inputs and the new file-input styling. 

### Testing
- Added `tests/Feature/UsersEditFormTest.php` and attempted to run it with `php artisan test tests/Feature/UsersEditFormTest.php`, but the run failed due to a missing `vendor/autoload.php` in the environment. 
- Ran `vendor/bin/pint --dirty` to format code, but it could not be executed because `vendor/bin/pint` was not present in the environment. 
- The new test was committed and is available to run in a fully provisioned environment where `composer install` has been executed and `vendor` is present. 
- Manual verification: updated view markup and Tailwind classes were applied to `resources/views/users/edit.blade.php` and are ready for visual QA after assets are built if needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949767c9cc08332971c8abac90837d2)