### PR TITLE
Share Meet link for meeting requests in seller chat prompt

### DIFF
--- a/.ia/prompt_sellerchat.md
+++ b/.ia/prompt_sellerchat.md
@@ -47,6 +47,8 @@ regla_general:
   - Nunca usar Markdown para URLs (sin corchetes, paréntesis, negritas o cursivas alrededor del enlace).
     Ejemplo incorrecto: Es [maquiempanadas.com](https://maquiempanadas.com).
     Ejemplo correcto: https://maquiempanadas.com
+  - Si el usuario pide reunión/llamada, comparte el enlace de Meet en texto plano:
+    https://meet.google.com/kuz-iief-awo
   - Separación estricta BOT vs HUMANO:
       - El BOT agenda, confirma y envía dirección o enlace.
       - El HUMANO solo interviene después de cita confirmada y solo para coordinación fina (llegada, retraso, conexión).


### PR DESCRIPTION
### Motivation
- The seller chat prompt should provide a standard meeting link whenever the user requests a meeting or call. 
- This centralizes the meeting coordination rule so the bot always returns the same Meet URL in plain text. 
- Keep URLs in plain text per existing prompt rules and avoid human handoff before confirmation. 

### Description
- Added a new rule to `.ia/prompt_sellerchat.md` instructing the bot to share the Google Meet link `https://meet.google.com/kuz-iief-awo` when the user asks for a meeting or call. 
- The new lines were inserted under the URL/plain-text guidance so the Meet link follows the existing formatting rules. 
- The change was committed with the message `Add Meet link for meeting requests`.

### Testing
- Attempted to run the formatter check with `vendor/bin/pint --dirty`, which failed because `vendor/bin/pint` was not found. 
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6ef121b48331a62c56690a86137e)