### PR TITLE
Add Meet link and availability note to seller chat confirmation

### DIFF
--- a/.ia/prompt_sellerchat.md
+++ b/.ia/prompt_sellerchat.md
@@ -47,6 +47,8 @@ regla_general:
   - Nunca usar Markdown para URLs (sin corchetes, paréntesis, negritas o cursivas alrededor del enlace).
     Ejemplo incorrecto: Es [maquiempanadas.com](https://maquiempanadas.com).
     Ejemplo correcto: https://maquiempanadas.com
+  - Si el usuario pide reunión/llamada, comparte el enlace de Meet en texto plano:
+    https://meet.google.com/kuz-iief-awo
   - Separación estricta BOT vs HUMANO:
       - El BOT agenda, confirma y envía dirección o enlace.
       - El HUMANO solo interviene después de cita confirmada y solo para coordinación fina (llegada, retraso, conexión).
@@ -342,6 +344,12 @@ feria_manizales_2026:
       Si es presencial:
       Dirección: Carrera 34 No 64-24 Manizales, Caldas
       Mapa: https://maps.app.goo.gl/xAD1vwnFavbEujZx7
+
+      Enlace de la videollamada:
+      https://meet.google.com/kuz-iief-awo
+
+      La sala está abierta de 9:00 am a 4:00 pm. Entra en ese horario.
+      Si no te deja entrar, escríbeme al 573004410097.
 
       Si necesitas coordinar algo puntual el mismo día,
       puedes escribirme directamente aquí:


### PR DESCRIPTION
### Motivation
- Ensure the bot shares a consistent Google Meet URL and provides availability hours and a fallback contact when users request a meeting or call.
- Keep the Meet URL delivered as plain text to comply with existing prompt rules for URLs.

### Description
- Added a new instruction under `regla_general` to share `https://meet.google.com/kuz-iief-awo` when the user asks for a meeting/llamada.
- Inserted `Enlace de la videollamada:`, the Meet URL, the availability note `La sala está abierta de 9:00 am a 4:00 pm. Entra en ese horario.`, and the fallback contact `Si no te deja entrar, escríbeme al 573004410097.` into the `confirmacion_cita` `mensaje` template in `.ia/prompt_sellerchat.md`.
- Preserved plain-text URL formatting and kept the existing WhatsApp contact link intact.

### Testing
- Ran `vendor/bin/pint --dirty`, which failed with `/bin/bash: line 1: vendor/bin/pint: No such file or directory`.
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6ef121b48331a62c56690a86137e)