### PR TITLE
Share Meet link on CUPOS trigger and add Meet details to confirmations

### DIFF
--- a/.ia/prompt_sellerchat.md
+++ b/.ia/prompt_sellerchat.md
@@ -47,6 +47,8 @@ regla_general:
   - Nunca usar Markdown para URLs (sin corchetes, paréntesis, negritas o cursivas alrededor del enlace).
     Ejemplo incorrecto: Es [maquiempanadas.com](https://maquiempanadas.com).
     Ejemplo correcto: https://maquiempanadas.com
+  - Si el usuario pide reunión/llamada, comparte el enlace de Meet en texto plano:
+    https://meet.google.com/kuz-iief-awo
   - Separación estricta BOT vs HUMANO:
       - El BOT agenda, confirma y envía dirección o enlace.
       - El HUMANO solo interviene después de cita confirmada y solo para coordinación fina (llegada, retraso, conexión).
@@ -279,7 +281,7 @@ feria_manizales_2026:
       - interes_feria_2026 = true
       - marcar estado_actual = feria_trigger
     respuesta_confirmacion: >
-      ¿Hoy ya produces empanadas u otro producto similar?
+      Enlace de la videollamada: https://meet.google.com/kuz-iief-awo
     reglas:
       - Mantener una sola pregunta por interacción.
       - No exponer estados internos ni lógica de scoring.
@@ -342,6 +344,12 @@ feria_manizales_2026:
       Si es presencial:
       Dirección: Carrera 34 No 64-24 Manizales, Caldas
       Mapa: https://maps.app.goo.gl/xAD1vwnFavbEujZx7
+
+      Enlace de la videollamada:
+      https://meet.google.com/kuz-iief-awo
+
+      La sala está abierta de 9:00 am a 4:00 pm. Entra en ese horario.
+      Si no te deja entrar, escríbeme al 573004410097.
 
       Si necesitas coordinar algo puntual el mismo día,
       puedes escribirme directamente aquí:


### PR DESCRIPTION
### Motivation
- Ensure the bot immediately shares a consistent Google Meet URL when the CUPOS subflow is triggered.
- Provide the Meet link and operational hours in appointment confirmations so users know when to join and who to contact if they can't enter.
- Preserve plain-text URL formatting to comply with existing prompt rules.

### Description
- Replaced the CUPOS trigger `respuesta_confirmacion` so it sends only the Meet URL instead of asking the initial yes/no question. 
- Added a global rule in `regla_general` to share the Meet link `https://meet.google.com/kuz-iief-awo` when the user requests a meeting/call. 
- Inserted the Meet link, the availability note (9:00 am–4:00 pm), and fallback contact `573004410097` into the `confirmacion_cita` `mensaje` template. 
- Modified the file `.ia/prompt_sellerchat.md` to apply the above changes.

### Testing
- Ran `vendor/bin/pint --dirty`, which failed with "No such file or directory" (exit code 127).
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6ef121b48331a62c56690a86137e)