### PR TITLE
Remove recent_actions_last sort and default to recent

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -122,7 +122,7 @@ class CustomerController extends Controller
         $menu = $this->customerService->getUserMenu(Auth::user());
 
         if (! $request->filled('sort')) {
-            $request->merge(['sort' => 'recent_actions_last']);
+            $request->merge(['sort' => 'recent']);
         }
 
         $defaultUserFilter = ! $request->has('user_id') && ! $request->filled('search');

--- a/app/Services/CustomerService.php
+++ b/app/Services/CustomerService.php
@@ -188,7 +188,7 @@ class CustomerService
 
         // Ordenamiento personalizado
         $sort = $request->get('sort');
-        $allowedSorts = ['recent', 'last_action', 'advisor', 'status', 'recent_actions_last'];
+        $allowedSorts = ['recent', 'last_action', 'advisor', 'status'];
         $sortKey = in_array($sort, $allowedSorts, true) ? $sort : 'status';
 
         if ($sortKey === 'last_action') {
@@ -199,19 +199,6 @@ class CustomerService
                 ->orderBy('advisor_sort.name', 'ASC');
         } elseif ($sortKey === 'recent') {
             $query->orderBy('customers.created_at', 'DESC');
-        } elseif ($sortKey === 'recent_actions_last') {
-            $recentActions = DB::table('actions')
-                ->select('customer_id', DB::raw('MAX(created_at) AS last_action_at'))
-                ->whereNotNull('creator_user_id')
-                ->whereNotIn('creator_user_id', [1, 2])
-                ->whereNull('deleted_at')
-                ->groupBy('customer_id');
-
-            $query->leftJoinSub($recentActions, 'recent_actions', function ($join) {
-                $join->on('recent_actions.customer_id', '=', 'customers.id');
-            })
-                ->orderByRaw('CASE WHEN recent_actions.last_action_at IS NULL THEN 0 ELSE 1 END ASC')
-                ->orderBy('customers.created_at', 'DESC');
         } elseif ($sortKey === 'status') {
             $query->orderByRaw('COALESCE(customer_statuses.weight, 9999) ASC')
                 ->orderBy('customers.created_at', 'DESC');


### PR DESCRIPTION
### Motivation
- Remove the `recent_actions_last` custom sort and switch the default customers sort to use the `recent` (created_at) ordering to simplify sorting logic.

### Description
- Change the default sort in `CustomerController::index` from `recent_actions_last` to `recent` by merging `['sort' => 'recent']` when none is provided.
- Remove `recent_actions_last` from the `$allowedSorts` array in `CustomerService::filterCustomers` and delete the branch that performed the `leftJoinSub` on `actions` and its specialized ordering.
- Preserve existing `last_action`, `advisor`, and `status` sort behaviors and keep the fallback sort key logic intact.

### Testing
- Attempted to run `vendor/bin/pint --dirty` for formatting checks, but the command failed because `vendor/bin/pint` was not present in the environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69740bde502483319b87d0430f9b36b6)