### PR TITLE
Optimize customer filtering: consolidate queries, extract helpers, and default sort to recent

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -122,7 +122,7 @@ class CustomerController extends Controller
         $menu = $this->customerService->getUserMenu(Auth::user());
 
         if (! $request->filled('sort')) {
-            $request->merge(['sort' => 'recent_actions_last']);
+            $request->merge(['sort' => 'recent']);
         }
 
         $defaultUserFilter = ! $request->has('user_id') && ! $request->filled('search');
@@ -138,8 +138,9 @@ class CustomerController extends Controller
         // dd($statuses);
         $query = $request->input('search');
 
-        $model = $this->customerService->filterCustomers($request, $statuses, null, false, 10);
-        $childGroups = $this->customerService->filterCustomers($request, $statuses, null, true);
+        $filterResult = $this->customerService->filterCustomersWithGroups($request, $statuses, null, 10);
+        $model = $filterResult['model'];
+        $childGroups = $filterResult['childGroups'];
         $parentStatuses = CustomerStatus::query()
             ->whereNull('parent_id')
             ->orderBy('weight')
@@ -152,8 +153,9 @@ class CustomerController extends Controller
             && ! $request->boolean('no_date');
 
         if ($defaultUserFilter && $usingDefaultDateRange && method_exists($model, 'total') && $model->total() === 0) {
-            $model = $this->customerService->filterCustomers($request, $statuses, null, false, 10, false);
-            $childGroups = $this->customerService->filterCustomers($request, $statuses, null, true, 0, false);
+            $filterResult = $this->customerService->filterCustomersWithGroups($request, $statuses, null, 10, false);
+            $model = $filterResult['model'];
+            $childGroups = $filterResult['childGroups'];
             $customersGroup = $this->customerService->groupStatusesByParent($childGroups, $parentStatuses);
         }
 


### PR DESCRIPTION
### Motivation
- Avoid executing the customer filter twice when building the list and status groups and ensure single-result searches redirect to the customer show page.
- Centralize common filter/sort/quote logic to make the query pipeline easier to maintain and to remove the legacy `recent_actions_last` sort.

### Description
- Added `buildCustomerQuery`, `applyHasQuoteFilter`, `applySort`, and `buildGroupCounts` helpers in `CustomerService` to encapsulate shared filter, quote, sort and group-count logic.
- Introduced `filterCustomersWithGroups(Request, ...)` that returns both the paginated/list model and status group counts from a single base query to avoid running filters twice.
- Updated `CustomerController::index` to use `filterCustomersWithGroups` and to preserve the behavior that redirects to `customers.show` when a search returns exactly one record; also defaults sort to `recent` when none is provided.
- Removed the `recent_actions_last` sort option from the allowed sorts and implemented `recent`, `last_action`, `advisor`, and `status` sort behaviors in the centralized `applySort` helper.
- Preserved existing annotations and access-limiting transformations on the resulting models and preserved the default-date-range fallback behavior by reusing the new combined query path.

### Testing
- Attempted to run formatting via `vendor/bin/pint --dirty`, which failed because `vendor/bin/pint` is not present in the environment. No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69740bde502483319b87d0430f9b36b6)