### PR TITLE
Show: replace image 'Link' with full customer URL and add copy button

### DIFF
--- a/resources/views/customers/show.blade.php
+++ b/resources/views/customers/show.blade.php
@@ -139,11 +139,19 @@
             <div class="space-y-3">
               <div class="space-y-0.5">
                 <div class="text-xs text-slate-500">Imagen</div>
-                <a href="{{ $model->image_url }}" class="text-sm text-blue-600 hover:underline">Link</a>
-              </div>
-              <div class="space-y-0.5">
-                <div class="text-xs text-slate-500">Nombre</div>
-                <div class="text-sm text-slate-900">{{ $model->name }}</div>
+                <div class="inline-flex items-center gap-2 text-sm text-slate-900">
+                  <a href="https://arichat.co/customers/{{ $model->id }}/show" class="text-blue-600 hover:underline">https://arichat.co/customers/{{ $model->id }}/show</a>
+                  <button
+                    type="button"
+                    class="inline-flex items-center text-slate-500 transition hover:text-slate-700"
+                    data-copy-text="https://arichat.co/customers/{{ $model->id }}/show"
+                    aria-label="Copiar enlace"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="18" height="18">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />
+                    </svg>
+                  </button>
+                </div>
               </div>
               @if(!empty($model->business))
               <div class="space-y-0.5">


### PR DESCRIPTION
### Motivation
- Replace the ambiguous "Link" anchor in the customer details with the actual customer URL and provide a copy-to-clipboard control, and remove the duplicated customer name shown in the details section.

### Description
- Modified `resources/views/customers/show.blade.php` to render `https://arichat.co/customers/{{ $model->id }}/show` instead of the generic "Link" and added a nearby button with `data-copy-text` and an SVG icon to copy the URL to the clipboard, and removed the second occurrence of the customer's name in the details panel.

### Testing
- Attempted to run `vendor/bin/pint --dirty` but it failed because `vendor/bin/pint` is not present in this environment, so no automated formatting/tests were executed; attempting `php artisan serve --host 0.0.0.0 --port 8000` also failed due to missing `vendor/autoload.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c792653988332b5f7b3ba8c8c343a)