### PR TITLE
Agregar seguimiento de duración (creation_seconds) en Actions

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -1899,6 +1899,13 @@ class CustomerController extends Controller
         if ($request->filled('date_programed')) {
             $model->due_date = $date_programed;
         }
+        $creationSeconds = $request->input('creation_seconds');
+        if ($creationSeconds !== null && $creationSeconds !== '' && is_numeric($creationSeconds)) {
+            $creationSeconds = (int) $creationSeconds;
+            if ($creationSeconds >= 0) {
+                $model->creation_seconds = $creationSeconds;
+            }
+        }
 
         $model->save();
         if (! is_null($request->status_id)) {

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -28,6 +28,7 @@ class Action extends Model
         'sale_date',
         'sale_amount',
         'reminder_type',
+        'creation_seconds',
     ];
 
     /** Casts para fechas y numéricos. */
@@ -38,6 +39,7 @@ class Action extends Model
         'customer_updated_at' => 'datetime',
         'sale_date' => 'date',
         'sale_amount' => 'decimal:2',
+        'creation_seconds' => 'integer',
     ];
 
     protected static function booted(): void

--- a/database/migrations/2025_02_14_000000_add_creation_seconds_to_actions_table.php
+++ b/database/migrations/2025_02_14_000000_add_creation_seconds_to_actions_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('actions')) {
+            return;
+        }
+
+        if (! Schema::hasColumn('actions', 'creation_seconds')) {
+            Schema::table('actions', function (Blueprint $table) {
+                $table->unsignedInteger('creation_seconds')->nullable()->after('reminder_type');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('actions')) {
+            return;
+        }
+
+        if (Schema::hasColumn('actions', 'creation_seconds')) {
+            Schema::table('actions', function (Blueprint $table) {
+                $table->dropColumn('creation_seconds');
+            });
+        }
+    }
+};

--- a/resources/views/customers/index_partials/time_line.blade.php
+++ b/resources/views/customers/index_partials/time_line.blade.php
@@ -17,6 +17,7 @@
           'type_name' => $action->getTypeName(), // nombre del tipo
           'is_pending' => $action->isPending(),  // estado pendiente
           'due_date' => $action->due_date,       // fecha de vencimiento
+          'creation_seconds' => $action->creation_seconds,
           
       ]);
   }
@@ -111,6 +112,18 @@
             <span class="text-muted small">
               {{ $item['type_name'] ?? 'Tipo no definido' }}
             </span>
+
+            @if(!empty($item['creation_seconds']))
+              @php
+                $durationSeconds = (int) $item['creation_seconds'];
+                $durationLabel = $durationSeconds >= 3600
+                  ? gmdate('H:i:s', $durationSeconds)
+                  : gmdate('i:s', $durationSeconds);
+              @endphp
+              <div class="text-muted small">
+                ⏱ Duración: {{ $durationLabel }}
+              </div>
+            @endif
 
           </div>
 

--- a/resources/views/customers/partials/customer_overlay.blade.php
+++ b/resources/views/customers/partials/customer_overlay.blade.php
@@ -146,6 +146,9 @@
           if (window.initActionDateToggle) {
             window.initActionDateToggle($('#customer_overlay_body'));
           }
+          if (window.initActionCreationTimer) {
+            window.initActionCreationTimer($('#customer_overlay_body'));
+          }
         } else {
           window.location.href = url;
         }


### PR DESCRIPTION
### Motivation
- Registrar cuánto tarda el usuario en crear una acción para poder mostrar la duración en la línea de tiempo y mantener la información cuando se crea la acción.

### Description
- Almaceno `creation_seconds` desde `storeAction()` en `app/Http/Controllers/CustomerController.php` cuando viene en el request y es un número válido.
- Agregué `creation_seconds` a `$fillable` y a `$casts` en el modelo `App/Models/Action.php` para permitir asignación masiva y casteo a entero.
- Creé la migración `database/migrations/2025_02_14_000000_add_creation_seconds_to_actions_table.php` que añade la columna `creation_seconds` como `unsignedInteger` nullable en la tabla `actions`.
- Muestro la duración en `resources/views/customers/index_partials/time_line.blade.php` como `⏱ Duración: mm:ss` o `hh:mm:ss` y re-inicializo el timer del formulario cuando el overlay del cliente se carga en `resources/views/customers/partials/customer_overlay.blade.php`.

### Testing
- Intenté correr el formateador con `vendor/bin/pint --dirty` pero falló porque `vendor/` no está instalado (`vendor/bin/pint` no encontrado).
- No se ejecutaron tests de `phpunit` ni `pest` en este entorno y la migración fue creada pero no aplicada aquí porque `artisan` requiere dependencias instaladas.
- Verificación manual: se aplicaron cambios de código y se hizo commit (`Add action creation duration tracking`) en el repositorio local exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ae78e8388332951c1cf0e6f145f5)