### PR TITLE
Show action durations in customer timeline

### DIFF
--- a/resources/views/customers/show_partials/actions_widget_wp.blade.php
+++ b/resources/views/customers/show_partials/actions_widget_wp.blade.php
@@ -6,8 +6,10 @@
   $timeline = collect();
   $chatMessages = $chatMessages ?? collect();
 
+  $actions = $actions ?? $customer->actions ?? collect();
+
   // Agregamos acciones
-  foreach ($customer->actions as $action) {
+  foreach ($actions as $action) {
       $timeline->push([
           'type' => 'action',
           'id' => $action->id,
@@ -21,6 +23,7 @@
           'is_pending' => $action->isPending(),
           'due_date' => $action->due_date,
           'type_id' => $action->type_id,
+          'creation_seconds' => $action->creation_seconds,
           'status_id' => $customer->status_id,
           'customer_name' => $customer->name,
       ]);
@@ -108,6 +111,18 @@
             <span class="text-xs text-slate-500">
               {{ $item['type_name'] }}
             </span>
+
+            @if(!empty($item['creation_seconds']))
+              @php
+                $durationSeconds = (int) $item['creation_seconds'];
+                $durationLabel = $durationSeconds >= 3600
+                  ? gmdate('H:i:s', $durationSeconds)
+                  : gmdate('i:s', $durationSeconds);
+              @endphp
+              <div class="text-xs text-slate-500">
+                ⏱ Duración: {{ $durationLabel }}
+              </div>
+            @endif
           </div>
           <div class="text-right text-xs text-slate-500">
             {{ \Carbon\Carbon::parse($item['date'])->format('d M Y H:i') }}<br>


### PR DESCRIPTION
### Motivation
- Asegurar que la vista de la línea de tiempo use las acciones que pudiera proveer el controlador y no solo la relación `customer->actions`, evitando que no se muestren entradas cuando el controlador pasa una colección diferente.
- Mostrar la duración registrada de una acción (`creation_seconds`) en la línea de tiempo para que el equipo vea cuánto tiempo tardó la creación de cada acción.
- Mantener compatibilidad cuando no existan acciones, evitando errores de plantilla con colecciones nulas.

### Description
- Cambiado `resources/views/customers/show_partials/actions_widget_wp.blade.php` para usar ` $actions = $actions ?? $customer->actions ?? collect();` como fuente de acciones al construir la línea de tiempo.
- Se añadió el campo `'creation_seconds' => $action->creation_seconds` al objeto de entrada del timeline para cada acción.
- Se añadió renderizado formateado de la duración en la vista (⏱ mm:ss o hh:mm:ss) justo después del tipo de acción cuando `creation_seconds` está presente.

### Testing
- Intenté ejecutar el formateador con `vendor/bin/pint --dirty`, pero el binario no está disponible en este entorno y la ejecución falló; no se ejecutaron tests automáticos adicionales.
- La plantilla modificada fue añadida y commiteada (`git commit`) exitosamente en el branch de trabajo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981b11f26248332ae176c98ab92c702)