### PR TITLE
Add customer status filter for assigned chats

### DIFF
--- a/resources/views/livewire/customer-assigned-conversations.blade.php
+++ b/resources/views/livewire/customer-assigned-conversations.blade.php
@@ -11,7 +11,7 @@
                     </span>
                 </section>
 
-                <section>
+                <section class="flex flex-col gap-3">
                     <div class="grid grid-cols-12 items-center rounded-lg bg-gray-100 px-2 dark:bg-gray-800">
                         <label for="assigned-chats-search" class="col-span-1">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
@@ -26,11 +26,20 @@
                             class="col-span-11 w-full border-0 bg-inherit text-sm outline-none focus:outline-none focus:ring-0 hover:ring-0 dark:text-white">
                     </div>
                     @if ((int) auth()->user()->role_id === 1)
-                        <label class="mt-3 flex items-center gap-2 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                        <label class="flex items-center gap-2 text-xs font-semibold text-slate-600 dark:text-slate-300">
                             <input type="checkbox" wire:model.live="adminOnlyMyAssigned" class="rounded border-slate-300 text-slate-700 focus:ring-slate-500">
                             Solo mis clientes asignados
                         </label>
                     @endif
+                    <div class="grid gap-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                        <label for="customer-status-filter">Estado del cliente</label>
+                        <select id="customer-status-filter" wire:model.live="customerStatusId" class="w-full rounded-md border border-slate-200 bg-white px-2 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-slate-100">
+                            <option value="">Todos los estados</option>
+                            @foreach ($customerStatuses as $status)
+                                <option value="{{ $status->id }}">{{ $status->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
                 </section>
             </header>
 


### PR DESCRIPTION
### Motivation
- Provide a way to filter the customer-assigned conversations list by the customer's `status` so advisors can focus on already-evaluated or specific-status customers.
- Surface the available `CustomerStatus` options in the UI so users can quickly select a status to filter the chat list.

### Description
- Added `customerStatusId` and `customerStatuses` properties to `App\Livewire\CustomerAssignedConversations` and load statuses in `mount()` using `CustomerStatus::query()->orderBy('weight')->get(['id','name'])`.
- Implemented `updatedCustomerStatusId()` to reset pagination and selection when the filter changes.
- Applied a query condition in `accessibleConversationsQuery()` to `whereHasMorph('participantable', [Customer::class])` and filter by `status_id` when `customerStatusId` is set.
- Added a status filter dropdown to `resources/views/livewire/customer-assigned-conversations.blade.php` bound to `wire:model.live="customerStatusId"` with an option for "Todos los estados" and the loaded statuses.

### Testing
- Attempted to run the formatter `vendor/bin/pint --dirty`, but it failed because `vendor/bin/pint` was not present in the environment (formatting not applied).
- Attempted to boot the application with `php artisan serve`, but it failed due to missing `vendor/autoload.php`, so runtime/manual verification could not be performed.
- No automated unit or feature tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983d69cd30c8332bd7b9a31939308f1)