### PR TITLE
Normalize action audio URLs to HTTPS before rendering audio player

### DIFF
--- a/resources/views/actions/table_data.blade.php
+++ b/resources/views/actions/table_data.blade.php
@@ -19,7 +19,14 @@
         </div>
         @if(!empty($action->url))
           @php
-            $lowerUrl = Str::lower($action->url);
+            $audioUrl = trim($action->url);
+            if (! Str::startsWith($audioUrl, ['http://', 'https://'])) {
+              $audioUrl = 'https://'.$audioUrl;
+            }
+            if (Str::startsWith($audioUrl, 'http://')) {
+              $audioUrl = 'https://'.Str::after($audioUrl, 'http://');
+            }
+            $lowerUrl = Str::lower($audioUrl);
             $isAudio = Str::contains($lowerUrl, [
               '.mp3', '.wav', '.ogg', '.oga', '.m4a', '.m4b', '.webm',
               'backend.channels.app/recording-files/',
@@ -31,9 +38,9 @@
               (Str::contains($lowerUrl, '.webm') ? 'audio/webm' : null))));
           @endphp
           @if($isAudio)
-            <audio controls class="mt-2" @if(! $mime) src="{{ $action->url }}" @endif>
+            <audio controls class="mt-2" @if(! $mime) src="{{ $audioUrl }}" @endif>
               @if($mime)
-                <source src="{{ $action->url }}" type="{{ $mime }}">
+                <source src="{{ $audioUrl }}" type="{{ $mime }}">
               @endif
               Tu navegador no soporta el audio.
             </audio><br>


### PR DESCRIPTION
### Motivation
- Some action audio links were missing a scheme or used `http://`, causing browsers to fail loading the audio player or trigger mixed-content issues, so the view must normalize URLs to usable `https://` sources.

### Description
- Update `resources/views/actions/table_data.blade.php` to `trim()` the action URL, prepend `https://` when no scheme is present and replace `http://` with `https://`, then use the normalized `$audioUrl` for the `<audio>` `src` and `<source>` elements.

### Testing
- Attempted to run `vendor/bin/pint --dirty` but it failed because `pint` is not available in the environment, and no automated test suite (PHPUnit/Pest) was executed; the change was manually inspected and committed (`resources/views/actions/table_data.blade.php`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985673fbfbc8332b9a8d837db80f740)