### PR TITLE
Fix audio player overflow in customer timeline

### DIFF
--- a/resources/views/customers/show_partials/actions_widget_wp.blade.php
+++ b/resources/views/customers/show_partials/actions_widget_wp.blade.php
@@ -86,7 +86,7 @@
     <div class="rounded-lg border border-slate-200 border-l-4 bg-white p-4 shadow-sm" style="border-left-color: {{ $item['color'] }};">
       @if($item['type'] === 'action')
         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
+          <div class="min-w-0 flex-1">
             {{-- ⏰ Pendiente programado --}}
             @if($item['is_pending'] && $item['due_date'])
               <span class="text-xs font-semibold text-red-600">
@@ -104,7 +104,7 @@
 
             {{-- 🎧 Reproductor si es llamada --}}
             @if(!empty($item['url']) && (int) $item['type_id'] === 21)
-              <audio controls class="mt-2">
+              <audio controls class="mt-2 w-full max-w-full">
                 <source src="{{ $item['url'] }}" type="audio/ogg">
                 Tu navegador no soporta el audio.
               </audio><br>
@@ -113,7 +113,7 @@
             @if(!empty($item['url']) && (int) $item['type_id'] === 21)
               <div class="mt-2 space-y-2">
                 @if(($item['transcription_status'] ?? null) === 'done' && ! empty($item['transcription_text']))
-                  <div class="whitespace-pre-line rounded-md border border-slate-200 bg-slate-50 p-2 text-sm text-slate-700">
+                  <div class="whitespace-pre-line break-words rounded-md border border-slate-200 bg-slate-50 p-2 text-sm text-slate-700">
                     {{ $item['transcription_text'] }}
                   </div>
                 @elseif(in_array($item['transcription_status'] ?? '', ['pending', 'processing'], true))


### PR DESCRIPTION
### Motivation
- Prevent audio player and transcription text from overflowing the customer timeline card when the timeline is inside nested columns/cards.

### Description
- Updated `resources/views/customers/show_partials/actions_widget_wp.blade.php` to allow the action content to shrink in flex layouts by adding `min-w-0 flex-1` to the content container.
- Constrained the audio element to the available width with `class="mt-2 w-full max-w-full"` so the player no longer overflows its column.
- Ensured transcription text wraps by adding `break-words` to the transcription container instead of allowing horizontal overflow.

### Testing
- Ran the formatter check `vendor/bin/pint --dirty` which failed because `vendor/bin/pint` was not present in the environment (no formatting run possible).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985685d4704833285ced45cbd3d574a)