### PR TITLE
Fix audio URL normalization for actions list

### DIFF
--- a/resources/views/actions/table_data.blade.php
+++ b/resources/views/actions/table_data.blade.php
@@ -20,11 +20,11 @@
         @if(!empty($action->url))
           @php
             $audioUrl = trim($action->url);
+            if (Str::startsWith($audioUrl, '//')) {
+              $audioUrl = 'https:'.$audioUrl;
+            }
             if (! Str::startsWith($audioUrl, ['http://', 'https://'])) {
               $audioUrl = 'https://'.$audioUrl;
-            }
-            if (Str::startsWith($audioUrl, 'http://')) {
-              $audioUrl = 'https://'.Str::after($audioUrl, 'http://');
             }
             $lowerUrl = Str::lower($audioUrl);
             $isAudio = Str::contains($lowerUrl, [


### PR DESCRIPTION
### Motivation
- Audio players in the actions list were broken because some audio `url` values were being normalized incorrectly (protocol-relative `//` links were not handled and `http://` was being forced to `https://`), causing the action list playback to fail while other views loaded audio correctly.

### Description
- Update `resources/views/actions/table_data.blade.php` to prepend `https:` for protocol-relative URLs that start with `//` and remove the unconditional rewrite from `http://` to `https://`, while preserving the existing fallback that prefixes schemeless URLs with `https://`.

### Testing
- Attempted to run `vendor/bin/pint --dirty` for formatting, but the binary is not available in the environment so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985695f92948332864516960d275723)