### PR TITLE
Improve mobile readability in customers message count report

### DIFF
--- a/resources/views/reports/views/customers_by_message_count.blade.php
+++ b/resources/views/reports/views/customers_by_message_count.blade.php
@@ -89,10 +89,8 @@
       <thead class="bg-slate-50">
         <tr>
           <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Cliente</th>
-          <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Etiquetas</th>
-          <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Mensajes</th>
-          <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Ultimas 3 acciones</th>
           <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Ultimos 5 mensajes</th>
+          <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Ultimas 3 acciones</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-slate-100 text-sm text-slate-700">
@@ -132,22 +130,43 @@
                     {{ $item->status_name ?? 'Sin estado' }}
                   </span>
                 </div>
+                <div class="flex flex-wrap items-center gap-2 text-xs">
+                  <span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 font-semibold text-slate-600">
+                    Mensajes: {{ $item->messages_count }}
+                  </span>
+                  @if (count($tagNames))
+                    @foreach ($tagNames as $tagName)
+                      <span class="inline-flex items-center rounded-full bg-slate-100 px-2 py-1 font-semibold text-slate-600">
+                        {{ $tagName }}
+                      </span>
+                    @endforeach
+                  @else
+                    <span class="text-slate-400">Sin etiqueta</span>
+                  @endif
+                </div>
               </div>
             </td>
             <td class="px-4 py-3">
-              @if (count($tagNames))
-                <div class="flex flex-wrap gap-2">
-                  @foreach ($tagNames as $tagName)
-                    <span class="inline-flex items-center rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600">
-                      {{ $tagName }}
-                    </span>
+              @php
+                $lastMessages = $item->last_messages_body ? explode("\n", $item->last_messages_body) : [];
+              @endphp
+              @if (count($lastMessages))
+                <div class="flex flex-col gap-3 text-sm text-slate-600">
+                  @foreach ($lastMessages as $messageLine)
+                    @php
+                      $parts = array_pad(explode('|||', $messageLine), 2, '');
+                      [$messageBody, $messageDate] = $parts;
+                    @endphp
+                    <div class="space-y-1">
+                      <div>{{ $messageBody ?: 'Sin mensaje' }}</div>
+                      <div class="text-xs text-slate-400">{{ $messageDate ?: '—' }}</div>
+                    </div>
                   @endforeach
                 </div>
               @else
-                <span class="text-xs text-slate-400">Sin etiqueta</span>
+                <span class="text-sm text-slate-400">Sin mensajes</span>
               @endif
             </td>
-            <td class="px-4 py-3 font-semibold text-slate-900">{{ $item->messages_count }}</td>
             <td class="px-4 py-3">
               @php
                 $lastActions = $item->last_actions ? explode("\n", $item->last_actions) : [];
@@ -188,27 +207,6 @@
                 </div>
               @else
                 <span class="text-sm text-slate-400">Sin acciones</span>
-              @endif
-            </td>
-            <td class="px-4 py-3">
-              @php
-                $lastMessages = $item->last_messages_body ? explode("\n", $item->last_messages_body) : [];
-              @endphp
-              @if (count($lastMessages))
-                <div class="flex flex-col gap-3 text-sm text-slate-600">
-                  @foreach ($lastMessages as $messageLine)
-                    @php
-                      $parts = array_pad(explode('|||', $messageLine), 2, '');
-                      [$messageBody, $messageDate] = $parts;
-                    @endphp
-                    <div class="space-y-1">
-                      <div>{{ $messageBody ?: 'Sin mensaje' }}</div>
-                      <div class="text-xs text-slate-400">{{ $messageDate ?: '—' }}</div>
-                    </div>
-                  @endforeach
-                </div>
-              @else
-                <span class="text-sm text-slate-400">Sin mensajes</span>
               @endif
             </td>
           </tr>


### PR DESCRIPTION
### Motivation
- The customers-by-message-count table was overcrowded on small screens, so the UI should put the message label/count inside the customer block, remove the separate columns, and show messages before commercial actions to improve mobile readability.

### Description
- Updated `resources/views/reports/views/customers_by_message_count.blade.php` to remove the standalone `Etiquetas` and `Mensajes` table columns and to reorder the detail columns so `Ultimos 5 mensajes` appears before `Ultimas 3 acciones`.
- Moved the message count (`Mensajes: {{ $item->messages_count }}`) and tag badges into the `Cliente` cell and adjusted classes for a compact, mobile-friendly layout.
- This is a UI-only Blade change with no backend or data-model modifications.

### Testing
- Ran `vendor/bin/pint --dirty` but it failed because the `vendor/` directory (and `vendor/bin/pint`) is not available in this environment.
- Ran `php artisan test --filter=customersByMessageCount` but it failed due to missing `vendor/autoload.php` in this environment.
- Attempted a mobile screenshot with Playwright, but the automated run was rejected for missing `ports_to_forward` configuration and no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c411498083328ae8b660798319d5)