### PR TITLE
Support exact quoted message search in customers messages report

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -694,8 +694,15 @@ class ReportController extends Controller
         $messagesExistQuery->whereBetween('wire_messages.created_at', [$fromDate, $toDate]);
 
         if ($request->filled('message_search')) {
-            $searchTerm = '%'.$request->input('message_search').'%';
-            $messagesExistQuery->where('wire_messages.body', 'like', $searchTerm);
+            $messageSearch = trim((string) $request->input('message_search'));
+            $quotedMessageSearch = preg_match("/^(['\"])(.*)\\1$/", $messageSearch, $matches) === 1;
+
+            if ($quotedMessageSearch) {
+                $messagesExistQuery->where('wire_messages.body', $matches[2]);
+            } else {
+                $searchTerm = '%'.$messageSearch.'%';
+                $messagesExistQuery->where('wire_messages.body', 'like', $searchTerm);
+            }
         }
 
         $model = Customer::query()

--- a/tests/Feature/CustomerMessagesReportTest.php
+++ b/tests/Feature/CustomerMessagesReportTest.php
@@ -61,6 +61,14 @@ it('orders customers by message count', function () {
         'body' => 'Primer mensaje',
     ]);
 
+
+    Message::create([
+        'conversation_id' => $lowConversation->id,
+        'sendable_type' => $lowVolumeCustomer->getMorphClass(),
+        'sendable_id' => $lowVolumeCustomer->id,
+        'body' => 'Palabra',
+    ]);
+
     Message::create([
         'conversation_id' => $highConversation->id,
         'sendable_type' => $highVolumeCustomer->getMorphClass(),
@@ -229,6 +237,12 @@ it('orders customers by message count', function () {
         ->get('/reports/views/customers_messages_count?message_search=Palabra')
         ->assertSee('Cliente Filtrado')
         ->assertDontSee('Cliente Poco Mensajes');
+
+
+    $this->actingAs($user)
+        ->get('/reports/views/customers_messages_count?message_search=%22Palabra%22')
+        ->assertSee('Cliente Poco Mensajes')
+        ->assertDontSee('Cliente Filtrado');
 
     $this->actingAs($user)
         ->get('/reports/views/customers_messages_count?action_note_search=automatica')


### PR DESCRIPTION
### Motivation
- Enable users to search for an exact message body when they wrap the search term in quotes (e.g. `"Palabra"`) on the customers messages count report.
- Preserve the existing partial `LIKE` behavior for unquoted searches so current filters keep working.

### Description
- Detect quoted `message_search` input in `customersByMessageCount` and, when quoted, apply an exact equality filter against `wire_messages.body`, otherwise keep the `LIKE` match; implemented with `preg_match` and `where`/`where(..., 'like', ...)` logic in `app/Http/Controllers/ReportController.php`.
- Added a test case to `tests/Feature/CustomerMessagesReportTest.php` that creates a message with body `Palabra` and asserts that an unquoted search (`?message_search=Palabra`) still matches partials while a quoted search (`?message_search=%22Palabra%22`) matches only the exact message.
- Modified files: `app/Http/Controllers/ReportController.php` and `tests/Feature/CustomerMessagesReportTest.php`.

### Testing
- Ran syntax checks with `php -l app/Http/Controllers/ReportController.php` and `php -l tests/Feature/CustomerMessagesReportTest.php`, and both reported no syntax errors.
- Attempted to run formatting (`vendor/bin/pint --dirty`) and `php artisan pint --dirty` but both could not run because `vendor/autoload.php` (dependencies) are not installed in this environment.
- Did not run the full test suite (`php artisan test` / Pest) due to the missing test environment/dependencies in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977aa24b908331babb8b55460baf1d)