### PR TITLE
Add datetime-range filtering and user selector to Activity Logs

### DIFF
--- a/app/Http/Controllers/ActivityLogController.php
+++ b/app/Http/Controllers/ActivityLogController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\ActivityLog;
+use App\Models\User;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 
@@ -29,8 +31,8 @@ class ActivityLogController extends Controller
         $search = trim((string) $request->get('q'));
         $action = trim((string) $request->get('action'));
         $userId = $request->get('user_id');
-        $fromDate = $request->get('from_date');
-        $toDate = $request->get('to_date');
+        $fromDateTime = $request->get('from_datetime');
+        $toDateTime = $request->get('to_datetime');
 
         $query = ActivityLog::with('user')->orderByDesc('id');
 
@@ -51,15 +53,19 @@ class ActivityLogController extends Controller
             $query->where('user_id', (int) $userId);
         }
 
-        if ($fromDate) {
-            $query->whereDate('created_at', '>=', $fromDate);
-        }
-
-        if ($toDate) {
-            $query->whereDate('created_at', '<=', $toDate);
+        if ($fromDateTime && $toDateTime) {
+            $query->whereBetween('created_at', [
+                Carbon::parse($fromDateTime),
+                Carbon::parse($toDateTime),
+            ]);
+        } elseif ($fromDateTime) {
+            $query->where('created_at', '>=', Carbon::parse($fromDateTime));
+        } elseif ($toDateTime) {
+            $query->where('created_at', '<=', Carbon::parse($toDateTime));
         }
 
         $actions = $this->getAvailableActions();
+        $users = $this->getAvailableUsers();
 
         $logs = $query->paginate($perPage)->withQueryString();
 
@@ -70,8 +76,9 @@ class ActivityLogController extends Controller
             'perPage' => $perPage,
             'action' => $action,
             'userId' => $userId,
-            'fromDate' => $fromDate,
-            'toDate' => $toDate,
+            'fromDateTime' => $fromDateTime,
+            'toDateTime' => $toDateTime,
+            'users' => $users,
         ]);
     }
 
@@ -100,5 +107,13 @@ class ActivityLogController extends Controller
             ->distinct()
             ->orderBy('action')
             ->pluck('action');
+    }
+
+    private function getAvailableUsers(): Collection
+    {
+        return User::query()
+            ->select(['id', 'name'])
+            ->orderBy('name')
+            ->get();
     }
 }

--- a/resources/views/activity_logs/index.blade.php
+++ b/resources/views/activity_logs/index.blade.php
@@ -75,14 +75,21 @@
                     @endforeach
                 </select>
             </div>
-            <div style="flex:1; min-width: 170px;">
-                <input type="date" name="from_date" value="{{ $fromDate }}" placeholder="Desde">
+            <div style="flex:1; min-width: 220px;">
+                <input type="datetime-local" name="from_datetime" value="{{ $fromDateTime }}" placeholder="Desde">
             </div>
-            <div style="flex:1; min-width: 170px;">
-                <input type="date" name="to_date" value="{{ $toDate }}" placeholder="Hasta">
+            <div style="flex:1; min-width: 220px;">
+                <input type="datetime-local" name="to_datetime" value="{{ $toDateTime }}" placeholder="Hasta">
             </div>
-            <div style="flex:1; min-width: 140px;">
-                <input type="number" name="user_id" value="{{ $userId }}" placeholder="User ID">
+            <div style="flex:1; min-width: 220px;">
+                <select name="user_id" class="form-control form-control-sm">
+                    <option value="">Todos los usuarios</option>
+                    @foreach($users as $user)
+                        <option value="{{ $user->id }}" @selected((string) $user->id === (string) $userId)>
+                            {{ $user->name }} (#{{ $user->id }})
+                        </option>
+                    @endforeach
+                </select>
             </div>
             <select name="per_page" class="form-control form-control-sm" onchange="this.form.submit()" style="max-width: 110px;">
                 @foreach([10,25,50,100] as $size)


### PR DESCRIPTION
### Motivation

- Allow filtering activity logs by precise datetimes instead of just dates to improve search accuracy.
- Provide a user dropdown to filter logs by user name instead of requiring a numeric `user_id` input.
- Keep the existing action and search filters while exposing available users for UI selection.

### Description

- Replace `from_date`/`to_date` request parameters with `from_datetime`/`to_datetime` and parse them via `Carbon::parse` in `ActivityLogController` to support `whereBetween` and open-ended ranges.
- Add `getAvailableUsers()` to `ActivityLogController` to return a list of users and include `users` in the view payload, and import `User` and `Carbon` at the top of the controller.
- Update the view `resources/views/activity_logs/index.blade.php` to use `datetime-local` inputs for `from_datetime`/`to_datetime` and render a `select` user dropdown populated from `users`, and update related variable names passed to the view.
- Keep existing search, action filters, pagination (`per_page`) behavior, and distinct actions retrieval via `getAvailableActions()`.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a568150edc833293e647dd37d8db21)